### PR TITLE
fix naming convention for constructor function modules

### DIFF
--- a/q3/test-run-q3.js
+++ b/q3/test-run-q3.js
@@ -1,8 +1,9 @@
 // Build Library Model with values for testing
 
-var book = require("./book.js"),
-  shelf = require("./shelf.js"),
-  library = require("./library.js");
+// Set Constructor Functions
+var Book = require("./book.js"),
+  Shelf = require("./shelf.js"),
+  Library = require("./library.js");
 
 
 var book1 = new Book("js way", "Jen N", "drama");


### PR DESCRIPTION
Found a bug in my variable naming. It's bringing in Constructors, so they should be capitalized to notify the dev that they should be used with the keyword "new". 
